### PR TITLE
minecraft-server: fixing quotes so volume will create correctly

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 25565
 ADD start.sh /start
 ADD start-minecraft.sh /start-minecraft
 
-VOLUME ['/data']
+VOLUME ["/data"]
 ADD server.properties /tmp/server.properties
 WORKDIR /data
 


### PR DESCRIPTION
Single quotes don't work for VOLUME, but double quotes do.