### PR TITLE
Adding gamerule.txt configuration file handling (optional)

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -253,5 +253,12 @@ do
   fi
 done
 
+# If we have a gamerules.txt file... feed that in to the server stdin
+if [ -f /data/gamerules.txt ];
+then
+    exec java $JVM_OPTS -jar $SERVER < /data/gamerules.txt
+else
+    exec java $JVM_OPTS -jar $SERVER
+fi
 
 exec java $JVM_OPTS -jar $SERVER

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -260,5 +260,3 @@ then
 else
     exec java $JVM_OPTS -jar $SERVER
 fi
-
-exec java $JVM_OPTS -jar $SERVER

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -253,10 +253,10 @@ do
   fi
 done
 
-# If we have a gamerules.txt file... feed that in to the server stdin
-if [ -f /data/gamerules.txt ];
+# If we have a bootstrap.txt file... feed that in to the server stdin
+if [ -f /data/bootstrap.txt ];
 then
-    exec java $JVM_OPTS -jar $SERVER < /data/gamerules.txt
+    exec java $JVM_OPTS -jar $SERVER < /data/bootstrap.txt
 else
     exec java $JVM_OPTS -jar $SERVER
 fi


### PR DESCRIPTION
I wanted to ensure that certain "/gamerule" settings were established on server startup. I made a simple change to feed in a gamerules.txt file in start-minecraft.sh, if the file is found in the /data directory.