### PR TITLE
Add Spigot support, and non-zip URLs

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -14,7 +14,8 @@ RUN useradd -M -s /bin/false --uid 1000 minecraft \
   && mkdir /data \
   && mkdir /config \
   && mkdir /mods \
-  && chown minecraft:minecraft /data /config /mods
+  && mkdir /plugins
+  && chown minecraft:minecraft /data /config /mods /plugins
 
 EXPOSE 25565
 
@@ -24,6 +25,7 @@ COPY start-minecraft.sh /start-minecraft
 VOLUME ["/data"]
 VOLUME ["/mods"]
 VOLUME ["/config"]
+VOLUME ["/plugins"]
 COPY server.properties /tmp/server.properties
 WORKDIR /data
 

--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -146,6 +146,57 @@ This works well if you want to have a common set of modules in a separate
 location, but still have multiple worlds with different server requirements
 in either persistent volumes or a downloadable archive.
 
+## Running a Bukkit/Spigot server
+
+Enable Bukkit/Spigot server mode by adding a `-e TYPE=BUKKIT -e VERSION=1.8` or `-e TYPE=SPIGOT -e VERSION=1.8` to your command-line.
+
+The VERSION option should be set to 1.8, as this is the only version of CraftBukkit and Spigot currently
+available.  The latest build in this branch will be used.
+
+    $ docker run -d -v /path/on/host:/data \
+        -e TYPE=SPIGOT -e VERSION=1.8 \
+        -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server
+
+You can install Bukkit plugins in two ways.
+
+### Using the /data volume
+
+This is the easiest way if you are using a persistent `/data` mount.
+
+To do this, you will need to attach the container's `/data` directory
+(see "Attaching data directory to host filesystem”).
+Then, you can add plugins to the `/path/on/host/plugins` folder you chose. From the example above,
+the `/path/on/host` folder contents look like:
+
+```
+/path/on/host
+├── plugins
+│   └── ... INSTALL PLUGINS HERE ...
+├── ops.json
+├── server.properties
+├── whitelist.json
+└── ...
+```
+
+If you add plugins while the container is running, you'll need to restart it to pick those
+up:
+
+    docker stop mc
+    docker start mc
+
+### Using separate mounts
+
+This is the easiest way if you are using an ephemeral `/data` filesystem,
+or downloading a world with the `WORLD` option.
+
+There is one additional volume that can be mounted; `/plugins`.  
+Any files in this filesystem will be copied over to the main
+`/data/plugins` filesystem before starting Minecraft.
+
+This works well if you want to have a common set of plugins in a separate 
+location, but still have multiple worlds with different server requirements
+in either persistent volumes or a downloadable archive.
+
 ## Using Docker Compose
 
 Rather than type the server options below, the port mappings above, etc

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -37,6 +37,26 @@ echo "Checking type information."
 case "$TYPE" in
   *BUKKIT|*bukkit|SPIGOT|spigot)
     TYPE=SPIGOT
+    case "$TYPE" in
+      *BUKKIT|*bukkit)
+        echo "Downloading latest CraftBukkit 1.8 server ..."
+        SERVER=craftbukkit_server.jar
+        ;;
+      *)
+        echo "Downloading latest Spigot 1.8 server ..."
+        SERVER=spigot_server.jar
+        ;;
+    esac
+    case $VANILLA_VERSION in
+      1.8*)
+        URL=/spigot18/$SERVER
+        ;;
+      *)
+        echo "That version of $SERVER is not available."
+        exit 1
+      ;;
+    esac
+    wget -q https://getspigot.org$URL
     ;;
 
   FORGE|forge)

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -33,19 +33,15 @@ esac
 
 cd /data
 
-echo "Checking minecraft / forge type information."
+echo "Checking type information."
 case "$TYPE" in
-  VANILLA)
-    SERVER="minecraft_server.$VANILLA_VERSION.jar"
+  *BUKKIT|*bukkit|SPIGOT|spigot)
+    TYPE=SPIGOT
+    ;;
 
-    if [ ! -e $SERVER ]; then
-      echo "Downloading $SERVER ..."
-      wget -q https://s3.amazonaws.com/Minecraft.Download/versions/$VANILLA_VERSION/$SERVER
-    fi
-  ;;
-
-  FORGE)
+  FORGE|forge)
     # norm := the official Minecraft version as Forge is tracking it. dropped the third part starting with 1.8
+    TYPE=FORGE
     case $VANILLA_VERSION in
       1.7.*)
         norm=$VANILLA_VERSION
@@ -56,16 +52,16 @@ case "$TYPE" in
       ;;
     esac
 
-   	echo "Checking Forge version information."
-  	case $FORGEVERSION in
-  	  RECOMMENDED)
+    echo "Checking Forge version information."
+    case $FORGEVERSION in
+        RECOMMENDED)
   		FORGE_VERSION=`wget -O - http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json | jsawk -n "out(this.promos['$norm-recommended'])"`
-  	  ;;
+        ;;
 
-  	  *)
+        *)
   		FORGE_VERSION=$FORGEVERSION
-  	  ;;
-  	esac
+        ;;
+    esac
 
     # URL format changed for 1.7.10 from 10.13.2.1300
     sorted=$((echo $FORGE_VERSION; echo 10.13.2.1300) | sort -V | head -1)
@@ -87,11 +83,26 @@ case "$TYPE" in
     fi
   ;;
 
+  VANILLA|vanilla|)
+    SERVER="minecraft_server.$VANILLA_VERSION.jar"
+
+    if [ ! -e $SERVER ]; then
+      echo "Downloading $SERVER ..."
+      wget -q https://s3.amazonaws.com/Minecraft.Download/versions/$VANILLA_VERSION/$SERVER
+    fi
+  ;;
+
+  *)
+      echo "Invalid type: '$TYPE'"
+      echo "Must be: VANILLA, FORGE, SPIGOT"
+      exit 1
+  ;;
+
 esac
 
 # If supplied with a URL for a world, download it and unpack
 case "X$WORLD" in
-  X[Hh][Tt][Tt][Pp]*[Zz][iI][pP])
+  X[Hh][Tt][Tt][Pp]*)
     echo "Downloading world via HTTP"
     echo "$WORLD"
     wget -q -O - "$WORLD" > /data/world.zip
@@ -107,6 +118,12 @@ case "X$WORLD" in
           mv -f "$d" /data/world
         fi
       done
+    fi
+    if [ "$TYPE" = "SPIGOT" ]; then
+      # Reorganise if a Spigot server
+      echo "Moving End and Nether maps to Spigot location"
+      [ -d "/data/world/DIM1" ] && mv -f "/data/world/DIM1" "/data/world_the_end"
+      [ -d "/data/world/DIM-1" ] && mv -f "/data/world/DIM-1" "/data/world_nether"
     fi
     ;;
   *)

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -103,7 +103,7 @@ case "$TYPE" in
     fi
   ;;
 
-  VANILLA|vanilla|)
+  VANILLA|vanilla)
     SERVER="minecraft_server.$VANILLA_VERSION.jar"
 
     if [ ! -e $SERVER ]; then

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -289,6 +289,11 @@ do
     cp -rf "$c" /data/config
   fi
 done
-
+if [ "$TYPE" = "SPIGOT" ]; then
+  echo Copying any Bukkit plugins over
+  if [ -d /plugins ]; then
+    cp -r /plugins /data
+  fi
+fi
 
 exec java $JVM_OPTS -jar $SERVER


### PR DESCRIPTION
- Allow world URLs to end in something other than .zip (fixes #50 )
- Some whitespace fixes (tabs->4space)
- Allow TYPE=SPIGOT and TYPE=BUKKIT.  Note that only version 1.8.8 is currently available.
- Rename directories for dimensions if TYPE=SPIGOT/BUKKIT
- Some text changes to reflect new features
- Allow type options to be lower-case
- Add documentation
- Add /plugins mount for external bukkit plugins (like /mods for forge mods)
