### PR TITLE
[mc] resolved issues with downloading new server executable

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -62,7 +62,8 @@ case "$TYPE" in
       ;;
     esac
 
-    rm -f $SERVER
+    #BAD Idea
+    #rm -f $SERVER
     wget -q https://getspigot.org$URL
 
     ;;

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -62,9 +62,8 @@ case "$TYPE" in
       ;;
     esac
 
-    #BAD Idea
-    #rm -f $SERVER
-    wget -q https://getspigot.org$URL
+    #attempt https, and if it fails, fallback to http and download that way. Display error if neither works.
+    wget -q -N spigot_server.jar https://getspigot.org$URL || (echo "Falling back to http, unable to contact server using https..." && wget -q -N spigot_server.jar http://getspigot.org$URL) || echo "Unable to download new copy of spigot server"
 
     ;;
 

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -63,7 +63,10 @@ case "$TYPE" in
     esac
 
     #attempt https, and if it fails, fallback to http and download that way. Display error if neither works.
-    wget -q -N spigot_server.jar https://getspigot.org$URL || (echo "Falling back to http, unable to contact server using https..." && wget -q -N spigot_server.jar http://getspigot.org$URL) || echo "Unable to download new copy of spigot server"
+    wget -q -N $SERVER https://getspigot.org$URL || \
+    	(echo "Falling back to http, unable to contact server using https..." && \
+    	wget -q -N $SERVER http://getspigot.org$URL) || \
+    	echo "Unable to download new copy of spigot server"
 
     ;;
 


### PR DESCRIPTION
Using this code, wget will download and overwrite spigot_server.jar if and ONLY if it can contact the server and download a copy. otherwise, it will leave the file alone. If -O was used, wget would overwrite the file with 0 bytes, effectively deleting it. In combination with -N and double pipe, bash will skip to the next statement if the first returns false or an error.