### PR TITLE
Add support for PAPER as possible Minecraft server

### DIFF
--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -209,6 +209,61 @@ This works well if you want to have a common set of plugins in a separate
 location, but still have multiple worlds with different server requirements
 in either persistent volumes or a downloadable archive.
 
+## Running a PaperSpigot server
+
+Enable PaperSpigot server mode by adding a `-e TYPE=PAPER -e VERSION=1.9.4` to your command-line.
+
+    docker run -d -v /path/on/host:/data \
+        -e TYPE=PAPER -e VERSION=1.9.4 \
+        -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server
+
+__NOTE: to avoid pegging the CPU when running PaperSpigot,__ you will need to 
+pass `--noconsole` at the very end of the command line and not use `-it`. For example,
+
+    docker run -d -v /path/on/host:/data \
+        -e TYPE=PAPER -e VERSION=1.9.4 \
+        -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server --noconsole
+
+You can install Bukkit plugins in two ways...
+
+### Using the /data volume
+
+This is the easiest way if you are using a persistent `/data` mount.
+
+To do this, you will need to attach the container's `/data` directory
+(see "Attaching data directory to host filesystem”).
+Then, you can add plugins to the `/path/on/host/plugins` folder you chose. From the example above,
+the `/path/on/host` folder contents look like:
+
+```
+/path/on/host
+├── plugins
+│   └── ... INSTALL PLUGINS HERE ...
+├── ops.json
+├── server.properties
+├── whitelist.json
+└── ...
+```
+
+If you add plugins while the container is running, you'll need to restart it to pick those
+up:
+
+    docker stop mc
+    docker start mc
+
+### Using separate mounts
+
+This is the easiest way if you are using an ephemeral `/data` filesystem,
+or downloading a world with the `WORLD` option.
+
+There is one additional volume that can be mounted; `/plugins`.  
+Any files in this filesystem will be copied over to the main
+`/data/plugins` filesystem before starting Minecraft.
+
+This works well if you want to have a common set of plugins in a separate
+location, but still have multiple worlds with different server requirements
+in either persistent volumes or a downloadable archive.
+
 ## Using Docker Compose
 
 Rather than type the server options below, the port mappings above, etc

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -80,6 +80,39 @@ function downloadSpigot {
   fi
 }
 
+function downloadPaper {
+  local build
+  case "$VERSION" in
+    latest|LATEST|1.10)
+      build="lastSuccessfulBuild";;
+    1.9.4)
+      build="773";;
+    1.9.2)
+      build="727";;
+    1.9)
+      build="612";;
+    1.8.8)
+      build="443";;
+    *)
+      build="nosupp";;
+  esac
+
+  if [ $build != "nosupp" ]; then
+    downloadUrl="https://ci.destroystokyo.com/job/PaperSpigot/$build/artifact/paperclip.jar"
+    wget -q -O $SERVER "$downloadUrl"
+    status=$?
+    if [ $status != 0 ]; then
+      echo "ERROR: failed to download from $downloadUrl due to (error code was $status)"
+      exit 3
+    fi
+  else
+    echo "ERROR: Version $VERSION is not supported for $TYPE"
+    echo "       Refer to https://ci.destroystokyo.com/job/PaperSpigot/"
+    echo "       for supported versions"
+    exit 2
+  fi
+}
+
 function installForge {
   TYPE=FORGE
   norm=$VANILLA_VERSION
@@ -156,6 +189,15 @@ case "$TYPE" in
     TYPE=SPIGOT
   ;;
 
+  PAPER|paper)
+    SERVER=paper_server.jar
+    if [ ! -f $SERVER ]; then
+      downloadPaper
+    fi
+    # normalize on Spigot for operations below
+    TYPE=SPIGOT
+  ;;
+  
   FORGE|forge)
     TYPE=FORGE
     installForge


### PR DESCRIPTION
Hey,

I went ahead and added support for PaperSpigot as possible Minecraft Server (PaperSpigot is drop-in replacement for Spigot, so not many changes were required). It sure needs improvement (like better version handling).

Fixes #96

Really like your work here, cheers!