### PR TITLE
minecraft-server: EULA var needs to be a string (docker-compose.yml)

### DIFF
--- a/minecraft-server/docker-compose.yml
+++ b/minecraft-server/docker-compose.yml
@@ -3,7 +3,7 @@ minecraft-server:
     - "25565:25565"
 
   environment:
-    EULA: TRUE
+    EULA: "TRUE"
 
   image: itzg/minecraft-server
 


### PR DESCRIPTION
docker-compose refuses to build a container without the quotation marks.