### PR TITLE
Use cURL insecurely when downloading

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -75,7 +75,7 @@ function downloadSpigot {
   fi
 
   echo "Downloading $match"
-  curl -fsSL -o $SERVER "$downloadUrl"
+  curl -kfsSL -o $SERVER "$downloadUrl"
   status=$?
   if [ ! -f $SERVER ]; then
     echo "ERROR: failed to download from $downloadUrl (status=$status)"


### PR DESCRIPTION
This fixes an error caused by the expired certificate on http://ci.mcadmin.net.

I know it's a sub-optimal solution but I can't see another solution until http://ci.mcadmin.net sorts out their certificate.