### PR TITLE
Add optional `nogui`

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -505,12 +505,12 @@ fi
 
 EXTRA_ARGS=""
 # Optional disable console
-if [[ ${CONSOLE} = false ]]; then
+if [[ ${CONSOLE} = false || ${CONSOLE} = FALSE ]]; then
   EXTRA_ARGS+="--noconsole"
 fi
 
 # Optional disable GUI for headless servers
-if [[ ${GUI} = false ]]; then
+if [[ ${GUI} = false || ${GUI} = FALSE ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} nogui"
 fi 
 

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -503,11 +503,16 @@ if [ "$TYPE" = "SPIGOT" ]; then
   fi
 fi
 
-if [[ $CONSOLE = false ]]; then
-  EXTRA_ARGS=--noconsole
-else
-  EXTRA_ARGS=""
+EXTRA_ARGS=""
+# Optional disable console
+if [[ ${CONSOLE} = false ]]; then
+  EXTRA_ARGS+="--noconsole"
 fi
+
+# Optional disable GUI for headless servers
+if [[ ${GUI} = false ]]; then
+  EXTRA_ARGS="${EXTRA_ARGS} nogui"
+fi 
 
 # put these prior JVM_OPTS at the end to give any memory settings there higher precedence
 echo "Setting initial memory to ${INIT_MEMORY:-${MEMORY}} and max to ${MAX_MEMORY:-${MEMORY}}"


### PR DESCRIPTION
If set via ENV, disable GUI on server.

Test script:
```
#! /bin/bash
CONSOLE=true
GUI=false
EXTRA_ARGS=""
if [[ ${CONSOLE} = false ]]; then
  EXTRA_ARGS+="--noconsole"
fi

# Optional disable GUI for headless servers
if [[ ${GUI} = false ]]; then
  EXTRA_ARGS="${EXTRA_ARGS} nogui"
fi 
echo $EXTRA_ARGS 
```

```
+ CONSOLE=false
+ GUI=false
+ EXTRA_ARGS=
+ [[ false = false ]]
+ EXTRA_ARGS+=--noconsole
+ [[ false = false ]]
+ EXTRA_ARGS='--noconsole nogui'
+ echo --noconsole nogui
--noconsole nogui
```
```
+ CONSOLE=true
+ GUI=false
+ EXTRA_ARGS=
+ [[ true = false ]]
+ [[ false = false ]]
+ EXTRA_ARGS=' nogui'
+ echo nogui
nogui
```
```
+ CONSOLE=true
+ GUI=true
+ EXTRA_ARGS=
+ [[ true = false ]]
+ [[ true = false ]]
+ echo

```