### PR TITLE
minecraft-server: Fixed FORGEVERSION case, add support for BIOMESOP

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -454,7 +454,7 @@ if [ ! -e server.properties ]; then
     echo "Setting level type to $LEVEL_TYPE"
     # check for valid values and only then set
     case $LEVEL_TYPE in
-      DEFAULT|FLAT|LARGEBIOMES|AMPLIFIED|CUSTOMIZED)
+      DEFAULT|FLAT|LARGEBIOMES|AMPLIFIED|CUSTOMIZED|BIOMESOP)
         sed -i "/level-type\s*=/ c level-type=$LEVEL_TYPE" /data/server.properties
         ;;
       *)

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -133,7 +133,7 @@ function installForge {
     esac
 
     echo "Checking Forge version information."
-    case $FORGE_VERSION in
+    case $FORGEVERSION in
       RECOMMENDED)
         curl -fsSL -o /tmp/forge.json http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
         FORGE_VERSION=$(cat /tmp/forge.json | jq -r ".promos[\"$VANILLA_VERSION-recommended\"]")
@@ -147,7 +147,9 @@ function installForge {
         fi
         ;;
 
-      *) ;;
+      *)
+        FORGE_VERSION=$FORGEVERSION
+        ;;
     esac
 
     normForgeVersion=$VANILLA_VERSION-$FORGE_VERSION-$norm

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -133,7 +133,7 @@ function installForge {
     esac
 
     echo "Checking Forge version information."
-    case $FORGEVERSION in
+    case $FORGE_VERSION in
       RECOMMENDED)
         curl -fsSL -o /tmp/forge.json http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
         FORGE_VERSION=$(cat /tmp/forge.json | jq -r ".promos[\"$VANILLA_VERSION-recommended\"]")
@@ -147,9 +147,7 @@ function installForge {
         fi
         ;;
 
-      *)
-        FORGE_VERSION=$FORGEVERSION
-        ;;
+      *) ;;
     esac
 
     normForgeVersion=$VANILLA_VERSION-$FORGE_VERSION-$norm


### PR DESCRIPTION
First of all: Thanks for your minecraft-server image, I really like it 👍 

* Fixed FORGEVERSION in case statement to working FORGE_VERSION
   * Removed default case because `FORGE_VERSION=$FORGE_VERSION` doesn't make a lot of sense if nothing needs to be changed.
* Add support for BIOMESOP level-type