### PR TITLE
Fix typos in config file generation

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -441,7 +441,7 @@ if [ ! -e server.properties ]; then
   setServerProp "allow-nether" "$ALLOW_NETHER"
   setServerProp "announce-player-achievements" "$ANNOUNCE_PLAYER_ACHIEVEMENTS"
   setServerProp "enable-command-block" "$ENABLE_COMMAND_BLOCK"
-  setServerProp "spawn-animals" "$SPAWN_ANIMAILS"
+  setServerProp "spawn-animals" "$SPAWN_ANIMALS"
   setServerProp "spawn-monsters" "$SPAWN_MONSTERS"
   setServerProp "spawn-npcs" "$SPAWN_NPCS"
   setServerProp "generate-structures" "$GENERATE_STRUCTURES"

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -526,7 +526,7 @@ if [ ! -e server.properties ]; then
         ;;
     esac
 
-    sed -i "/gamemode\s*=/ c gamemode=$MODE" $SERVER_PROPERTIES
+    sed -i "/^gamemode\s*=/ c gamemode=$MODE" $SERVER_PROPERTIES
   fi
 fi
 

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -445,7 +445,6 @@ if [ ! -e server.properties ]; then
   setServerProp "spawn-monsters" "$SPAWN_MONSTERS"
   setServerProp "spawn-npcs" "$SPAWN_NPCS"
   setServerProp "generate-structures" "$GENERATE_STRUCTURES"
-  setServerProp "spawn-npcs" "$SPAWN_NPCS"
   setServerProp "view-distance" "$VIEW_DISTANCE"
   setServerProp "hardcore" "$HARDCORE"
   setServerProp "max-build-height" "$MAX_BUILD_HEIGHT"


### PR DESCRIPTION
Env variable `SPAWN_ANIMALS` was misspelled as `SPAWN_ANIMAILS`, thus rendering the modification of this option in the config file from env variables non effective if the documentation is correctly followed.
Also, `spawn-npcs` was repeated two times.
Also, `force-gamemode` was never taken into account because of a regex issue.