### PR TITLE
Added option REMOVE_OLD_MODS

### DIFF
--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -672,6 +672,20 @@ To use this option pass the environment variable `MODPACK`, such as
 top level of the zip archive. Make sure the jars are compatible with the
 particular `TYPE` of server you are running.
 
+### Remove old mods/plugins
+
+When the option above is specified (`MODPACK`) you can also instruct script to
+delete old mods/plugins prior to installing new ones. This behaviour is desirable
+in case you want to upgrade mods/plugins from downloaded zip file.
+To use this option pass the environment variable `REMOVE_OLD_MODS="TRUE"`, such as
+
+    docker run -d -e REMOVE_OLD_MODS="TRUE" -e MODPACK=http://www.example.com/mods/modpack.zip ...
+
+**NOTE:** This option will be taken into account only when option `MODPACK` is also used.
+
+**WARNING:** All content of the `mods` or `plugins` directory will be deleted 
+before unpacking new content from the zip file.
+
 ### Online mode
 
 By default, server checks connecting players against Minecraft's account database. If you want to create an offline server or your server is not connected to the internet, you can disable the server to try connecting to minecraft.net to authenticate players with environment variable `ONLINE_MODE`, like this

--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -403,9 +403,15 @@ case "X$MODPACK" in
     echo "  from $MODPACK ..."
     curl -sSL -o /tmp/modpack.zip "$MODPACK"
     if [ "$TYPE" = "SPIGOT" ]; then
+      if [ "$REMOVE_OLD_MODS" = "TRUE" ]; then
+        rm -rf /data/plugins/*
+      fi
       mkdir -p /data/plugins
       unzip -o -d /data/plugins /tmp/modpack.zip
     else
+      if [ "$REMOVE_OLD_MODS" = "TRUE" ]; then
+        rm -rf /data/mods/*
+      fi
       mkdir -p /data/mods
       unzip -o -d /data/mods /tmp/modpack.zip
     fi


### PR DESCRIPTION
When the option `MODPACK` is specifed you can also instruct script to delete old mods/plugins prior to installing new ones.
This behaviour is desirable in case you want to upgrade or replace mods/plugins from downloaded zip file.
