### PR TITLE
Allow existing world volume mount for FTB

### DIFF
--- a/minecraft-server/start-deployFTB
+++ b/minecraft-server/start-deployFTB
@@ -13,48 +13,53 @@ if [[ -z $FTB_SERVER_MOD ]]; then
     echo "(And place the modpack in the /data directory.)"
     exit 2
 fi
-srv_modpack=${FTB_SERVER_MOD}
-if isURL ${srv_modpack}; then
-    case $srv_modpack in
-      https://www.feed-the-beast.com/*/download)
-        ;;
-      https://www.feed-the-beast.com/*)
-        srv_modpack=${srv_modpack}/download;;
-    esac
-    file=$(basename $(dirname $srv_modpack))
-    downloaded=/data/${file}.zip
-    if [ ! -e $downloaded ]; then
-      echo "Downloading FTB modpack...
-$srv_modpack -> $downloaded"
-      curl -sSL -o $downloaded $srv_modpack
-    fi
-    srv_modpack=$downloaded
-fi
-if [[ ${srv_modpack:0:5} == "data/" ]]; then
-    # Prepend with "/"
-    srv_modpack=/${srv_modpack}
-fi
-if [[ ! ${srv_modpack:0:1} == "/" ]]; then
-    # If not an absolute path, assume file is in "/data"
-    srv_modpack=/data/${srv_modpack}
-fi
-if [[ ! -f ${srv_modpack} ]]; then
-    echo "FTB server modpack ${srv_modpack} not found."
-    exit 2
-fi
-if [[ ! ${srv_modpack: -4} == ".zip" ]]; then
-    echo "FTB server modpack ${srv_modpack} is not a zip archive."
-    echo "Please set FTB_SERVER_MOD to a file with a .zip extension."
-    exit 2
-fi
 
-if [ ! -d ${FTB_DIR} ]; then
+# only download and install if a mod pack isn't already installed
+# also check for the start script rather than just the folder
+# this allows saving just the world separate from the rest of the data directory
+export FTB_SERVER_START=${FTB_DIR}/ServerStart.sh
+if [ ! -f ${FTB_SERVER_START} ]; then
+  srv_modpack=${FTB_SERVER_MOD}
+  if isURL ${srv_modpack}; then
+      case $srv_modpack in
+        https://www.feed-the-beast.com/*/download)
+          ;;
+        https://www.feed-the-beast.com/*)
+          srv_modpack=${srv_modpack}/download;;
+      esac
+      file=$(basename $(dirname $srv_modpack))
+      downloaded=/data/${file}.zip
+      if [ ! -e $downloaded ]; then
+        echo "Downloading FTB modpack...
+  $srv_modpack -> $downloaded"
+        curl -sSL -o $downloaded $srv_modpack
+      fi
+      srv_modpack=$downloaded
+  fi
+  if [[ ${srv_modpack:0:5} == "data/" ]]; then
+      # Prepend with "/"
+      srv_modpack=/${srv_modpack}
+  fi
+  if [[ ! ${srv_modpack:0:1} == "/" ]]; then
+      # If not an absolute path, assume file is in "/data"
+      srv_modpack=/data/${srv_modpack}
+  fi
+  if [[ ! -f ${srv_modpack} ]]; then
+      echo "FTB server modpack ${srv_modpack} not found."
+      exit 2
+  fi
+  if [[ ! ${srv_modpack: -4} == ".zip" ]]; then
+      echo "FTB server modpack ${srv_modpack} is not a zip archive."
+      echo "Please set FTB_SERVER_MOD to a file with a .zip extension."
+      exit 2
+  fi
+
   echo "Unpacking FTB server modpack ${srv_modpack} ..."
   mkdir -p ${FTB_DIR}
   unzip -o ${srv_modpack} -d ${FTB_DIR} | awk '{printf "."} END {print ""}'
   cp -f /data/eula.txt ${FTB_DIR}/eula.txt
 fi
-export FTB_SERVER_START=${FTB_DIR}/ServerStart.sh
+
 chmod a+x ${FTB_SERVER_START}
 sed -i "s/-jar/-Dfml.queryResult=confirm -jar/" ${FTB_SERVER_START}
 


### PR DESCRIPTION
The core of this pr allows a user to backup and restore only their world save rather than the whole minecraft data folder.