### PR TITLE
unzip fails if a file already exists in the zip file.

### DIFF
--- a/minecraft-server/start-finalSetup01World
+++ b/minecraft-server/start-finalSetup01World
@@ -7,7 +7,7 @@ case "X$WORLD" in
     echo "Downloading world from $WORLD"
     curl -sSL -o - "$WORLD" > /data/world.zip
     echo "Unzipping world"
-    unzip -q /data/world.zip
+    unzip -o -q /data/world.zip
     rm -f /data/world.zip
     if [ ! -d /data/world ]; then
       echo World directory not found


### PR DESCRIPTION
Unzipping world
replace banned-ips.json? [y]es, [n]o, [A]ll, [N]one, [r]ename:

unzip: can't read standard input