### PR TITLE
mc: run FTB installer from correct location

### DIFF
--- a/minecraft-server/start-deployFTB
+++ b/minecraft-server/start-deployFTB
@@ -87,11 +87,11 @@ fi
 
 if [ -e ${FTB_DIR}/FTBInstall.sh ]; then
   pushd ${FTB_DIR}
-  sh ${FTB_DIR}/FTBInstall.sh
+  sh FTBInstall.sh
   popd
 elif [ -e ${FTB_DIR}/Install.sh ]; then
   pushd ${FTB_DIR}
-  sh ${FTB_DIR}/Install.sh
+  sh Install.sh
   popd
 fi
 


### PR DESCRIPTION
We have pushd'ed into the directory so do not prefix the shell script
with the directory name.