### PR TITLE
mc: set umask to 0002 and chmod g+w the /data folder

### DIFF
--- a/minecraft-server/start
+++ b/minecraft-server/start
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+umask 0002
+chmod g+w /data
+
 if [ $(id -u) = 0 ]; then
   if [[ -v UID && $UID != $(id -u) ]]; then
     usermod -u $UID minecraft


### PR DESCRIPTION
Do this to allow write access for groups that the minecraft user is in.

This commit also fixes an issue if a group is specified with $GID and it has
no write access in the mounted host volume.