### PR TITLE
[minecraft-server] Pass all command line arguments to start-configura…

### DIFF
--- a/minecraft-server/start
+++ b/minecraft-server/start
@@ -16,7 +16,7 @@ if [ $(id -u) = 0 ]; then
     chown -R minecraft:minecraft /data
   fi
 
-  exec su-exec minecraft:minecraft /start-configuration
+  exec su-exec minecraft:minecraft /start-configuration $@
 else
-  exec /start-configuration
+  exec /start-configuration $@
 fi


### PR DESCRIPTION
Regarding the minecraft-server image
The start script currently does not pass command line arguments to the next script. This makes it so server admins can't easily update their server to 1.13.2 by passing --forceUpgrade as an extra parameter after specifying the docker image. With this change it works as intended.

Proof that the arguments did not get added before and do now:
* Add this line to the start-minecraftFinalSetup script (right before the exec): `echo "Running with: mc-server-runner ${bootstrapArgs} java $JVM_XX_OPTS $JVM_OPTS -jar $SERVER ""$@"" $EXTRA_ARGS"`
* Build the image
* Run the image with extra arguments `--test`
* See this printed: `Running with: mc-server-runner -jar minecraft_server.1.13.2.jar`
* Update to this PR
* Build the image
* See this printed: `Running with: mc-server-runner -jar minecraft_server.1.13.2.jar --test`