### PR TITLE
feat(minecraft-server): update spigot plugins using /plugins if newer

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache -U \
           jq \
           mysql-client \
           tzdata \
+          rsync \
           python python-dev py2-pip
 
 RUN pip install mcstatus

--- a/minecraft-server/start-minecraftFinalSetup
+++ b/minecraft-server/start-minecraftFinalSetup
@@ -36,13 +36,11 @@ done
 
 # If any modules have been provided, copy them over
 mkdir -p /data/mods
-for m in /mods/*.{jar,zip}
-do
-  if [ -f "$m" -a ! -f "/data/mods/$m" ]; then
-    echo Copying mod `basename "$m"`
-    cp "$m" /data/mods
-  fi
-done
+if [ -d /mods ]; then
+  echo "Copying any mods over..."
+  rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' -include '*.zip' --exclude '*' --update /mods /data/mods
+fi
+
 [ -d /data/config ] || mkdir /data/config
 for c in /config/*
 do
@@ -52,11 +50,10 @@ do
   fi
 done
 
+mkdir -p /data/plugins
 if [ "$TYPE" = "SPIGOT" ]; then
   if [ -d /plugins ]; then
-    # Copy all of the plugins directory first to include initial configs
-    echo Copying any Bukkit plugins over
-    cp -r /plugins /data
+    echo "Copying any Bukkit plugins over..."
     # Copy plugins over using rsync to allow deeply nested updates of plugins
     # only updates files if the source file is newer and print updated files
     rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' --exclude '*' --update /plugins /data/plugins

--- a/minecraft-server/start-minecraftFinalSetup
+++ b/minecraft-server/start-minecraftFinalSetup
@@ -38,7 +38,7 @@ done
 mkdir -p /data/mods
 if [ -d /mods ]; then
   echo "Copying any mods over..."
-  rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' -include '*.zip' --exclude '*' --update /mods /data/mods
+  rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' -include '*.zip' --exclude '*' --update /mods /data
 fi
 
 [ -d /data/config ] || mkdir /data/config
@@ -56,7 +56,7 @@ if [ "$TYPE" = "SPIGOT" ]; then
     echo "Copying any Bukkit plugins over..."
     # Copy plugins over using rsync to allow deeply nested updates of plugins
     # only updates files if the source file is newer and print updated files
-    rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' --exclude '*' --update /plugins /data/plugins
+    rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' --exclude '*' --update /plugins /data
   fi
 fi
 

--- a/minecraft-server/start-minecraftFinalSetup
+++ b/minecraft-server/start-minecraftFinalSetup
@@ -59,7 +59,7 @@ if [ "$TYPE" = "SPIGOT" ]; then
     cp -r /plugins /data
     # Copy plugins over using rsync to allow deeply nested updates of plugins
     # only updates files if the source file is newer and print updated files
-    rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.txt' --exclude '*' --update /plugins /data/plugins
+    rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.jar' --exclude '*' --update /plugins /data/plugins
   fi
 fi
 

--- a/minecraft-server/start-minecraftFinalSetup
+++ b/minecraft-server/start-minecraftFinalSetup
@@ -54,8 +54,12 @@ done
 
 if [ "$TYPE" = "SPIGOT" ]; then
   if [ -d /plugins ]; then
+    # Copy all of the plugins directory first to include initial configs
     echo Copying any Bukkit plugins over
     cp -r /plugins /data
+    # Copy plugins over using rsync to allow deeply nested updates of plugins
+    # only updates files if the source file is newer and print updated files
+    rsync -a --out-format="update:%f:Last Modified %M" --prune-empty-dirs --include '*/' --include '*.txt' --exclude '*' --update /plugins /data/plugins
   fi
 fi
 


### PR DESCRIPTION
Deep copy any *.jar files in /plugins and update the corresponding files in the /data/plugins dir.

The goal of this PR is to allow updating of plugins through child Docker images.

If wanted this can also be implemented for the /mods dir. May workaround implementing #267 and  #218 