### PR TITLE
feat(minecraft-server): add version argument for buildtools

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -31,6 +31,7 @@ EXPOSE 25565 25575
 ARG RESTIFY_VER=1.1.4
 ARG RCON_CLI_VER=1.4.0
 ARG MC_SERVER_RUNNER_VER=1.2.0
+ARG TOF_BUILDTOOLS_VER=1.2.0
 ARG ARCH=amd64
 
 ADD https://github.com/itzg/restify/releases/download/${RESTIFY_VER}/restify_${RESTIFY_VER}_linux_${ARCH}.tar.gz /tmp/restify.tgz
@@ -45,7 +46,7 @@ ADD https://github.com/itzg/mc-server-runner/releases/download/${MC_SERVER_RUNNE
 RUN tar -x -C /usr/local/bin -f /tmp/mc-server-runner.tgz mc-server-runner && \
   rm /tmp/mc-server-runner.tgz
 
-ADD https://git.faldoria.de/tof/server/build-tools/-/jobs/artifacts/master/raw/target/ToF-BuildTools.jar?job=deploy /tmp/tof-buildtools/BuildTools.jar
+ADD https://git.faldoria.de/tof/server/build-tools/-/jobs/artifacts/buildtools-${TOF_BUILDTOOLS_VER}/raw/target/ToF-BuildTools.jar?job=release-artifact /tmp/tof-buildtools/BuildTools.jar
 
 ONBUILD ARG BUILDTOOLS_OUTPUT=/plugins
 ONBUILD COPY Dockerfile *plugins.yml /tmp/tof-buildtools/


### PR DESCRIPTION
For future compatibility and to avoid breaking backwards compat I added a build argument with for the version of the build tools download.