### PR TITLE
Fix #287 : Support manifest.json

### DIFF
--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -409,7 +409,7 @@ To use these packs you will need to:
 
 An example of the latter would be to use https://github.com/AllTheMods/Server-Scripts
 There, you'll find that all you have to do is put `ServerStart.sh` and `settings.cfg` into
-`/data/FeedTheBeast`, taking care to update settings.cfg to specify your desired version
+`/data/FeedTheBeast`, taking care to update `settings.cfg` to specify your desired version
 of minecraft and forge. You can do this in the cli with something like:
 
 ```

--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -396,6 +396,42 @@ then you apply a workaround by adding this to the run invocation:
 
     -e FTB_LEGACYJAVAFIXER=true
 
+### Using a client-made curseforge modpack
+
+If you use something like curseforge, you may end up creating/using modpacks that do not
+contain server mod jars. Instead, the curseforge setup has `manifest.json` files, which
+will show up under `/data/FeedTheBeast/manifest.json`.
+
+To use these packs you will need to:
+
+- Specify the manifest location with env var `MANIFEST=/data/FeedTheBeast/manifest`
+- Pick a relevant ServerStart.sh and potentially settings.cfg and put them in `/data/FeedTheBeast`
+
+An example of the latter would be to use https://github.com/AllTheMods/Server-Scripts
+There, you'll find that all you have to do is put ServerStart.sh and settings.cfg into
+`/data/FeedTheBeast`, taking care to update settings.cfg to specify your desired version
+of minecraft and forge. You can do this in the cli with something like:
+
+```
+$ wget https://raw.githubusercontent.com/AllTheMods/Server-Scripts/master/ServerStart.sh
+$ wget https://raw.githubusercontent.com/AllTheMods/Server-Scripts/master/settings.cfg
+$ vim settings.cfg #update the forge version to the one you want. Your manifest.json will have it
+$ chmod +x ServerStart.sh
+$ docker run -itd --name derpcraft \
+  -e MANIFEST=/data/FeedTheBeast/manifest.json \
+  -v $PWD/ServerStart.sh:/data/FeedTheBeast/ServerStart.sh \
+  -v $PWD/settings.cfg:/data/FeedTheBeast/settings.cfg \
+  -e VERSION=1.12.2\
+  -e TYPE=CURSEFORGE\
+  -e CF_SERVER_MOD=https://minecraft.curseforge.com/projects/your_amazing_modpack/files/2670435/download\
+  -p 25565:25565\
+  -e EULA=TRUE\
+  --restart=always\
+  itzg/minecraft-server
+```
+
+Note the `CF_SERVER_MOD` env var should match the url to download the modpack you are targeting.
+
 ## Running a SpongeVanilla server
 
 Enable SpongeVanilla server mode by adding a `-e TYPE=SPONGEVANILLA` to your command-line.

--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -408,7 +408,7 @@ To use these packs you will need to:
 - Pick a relevant ServerStart.sh and potentially settings.cfg and put them in `/data/FeedTheBeast`
 
 An example of the latter would be to use https://github.com/AllTheMods/Server-Scripts
-There, you'll find that all you have to do is put ServerStart.sh and settings.cfg into
+There, you'll find that all you have to do is put `ServerStart.sh` and `settings.cfg` into
 `/data/FeedTheBeast`, taking care to update settings.cfg to specify your desired version
 of minecraft and forge. You can do this in the cli with something like:
 

--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -84,6 +84,7 @@ case "X$MANIFEST" in
     else
       echo "Could not find manifest file, unsufficient privs, or malformed path."
     fi
+    ;;
   *)
     echo "Invalid manifest file for modpack. Please make sure it is a .json file."
     ;;

--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -78,6 +78,7 @@ case "X$MANIFEST" in
       jq --slurpfile m "${MANIFEST}" '$m.files | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
       do
         url="${CURSE_URL_BASE}/${p}/files/${f}/download"
+        echo Downloading curseforge mod $url
         #  Manifest usually doesn't have mod names. Using id should be fine, tho
         curl -sSL -o /data/mods/${p}_${f}.jar
       done

--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -75,12 +75,17 @@ if [[ "$MANIFEST" ]]; then
 case "X$MANIFEST" in
   X*.json)
     if [ -f "${MANIFEST}" ]; then
-      jq --slurpfile m "${MANIFEST}" '$m.files | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
+      MOD_DIR=${FTB_BASE_DIR:-/data/mods}
+      echo "Starting manifest download..."
+      cat "${MANIFEST}" | jq -r '$.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
       do
-        url="${CURSE_URL_BASE}/${p}/files/${f}/download"
-        echo Downloading curseforge mod $url
-        #  Manifest usually doesn't have mod names. Using id should be fine, tho
-        curl -sSL -o /data/mods/${p}_${f}.jar
+        if [ ! -f $MOD_DIR/${p}_${f}.jar ]
+        then
+          url="${CURSE_URL_BASE}/${p}/files/${f}/download"
+          echo Downloading curseforge mod $url
+          #  Manifest usually doesn't have mod names. Using id should be fine, tho
+          curl -sSL "${url}" -o $MOD_DIR/${p}_${f}.jar
+        fi
       done
     else
       echo "Could not find manifest file, unsufficient privs, or malformed path."

--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#  CURSE_URL_BASE used in manifest downloads below
+CURSE_URL_BASE=${CURSE_URL_BASE:-https://minecraft.curseforge.com/projects}
+
 # Remove old mods/plugins
 if [ "$REMOVE_OLD_MODS" = "TRUE" ]; then
   if [ "$TYPE" = "SPIGOT" ]; then
@@ -66,6 +69,25 @@ do
       ;;
   esac
 done
+fi
+
+if [[ "$MANIFEST" ]]; then
+case "X$MANIFEST" in
+  X*.json)
+    if [ -f "${MANIFEST}" ]; then
+      jq --slurpfile m "${MANIFEST}" '$m.files | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
+      do
+        url="${CURSE_URL_BASE}/${p}/files/${f}/download"
+        #  Manifest usually doesn't have mod names. Using id should be fine, tho
+        curl -sSL -o /data/mods/${p}_${f}.jar
+      done
+    else
+      echo "Could not find manifest file, unsufficient privs, or malformed path."
+    fi
+  *)
+    echo "Invalid manifest file for modpack. Please make sure it is a .json file."
+    ;;
+esac
 fi
 
 exec /start-finalSetup03Modconfig $@


### PR DESCRIPTION
### Using a client-made curseforge modpack

If you use something like curseforge, you may end up creating/using modpacks that do not
contain server mod jars. Instead, the curseforge setup has `manifest.json` files, which
will show up under `/data/FeedTheBeast/manifest.json`.

To use these packs you will need to:

- Specify the manifest location with env var `MANIFEST=/data/FeedTheBeast/manifest`
- Pick a relevant ServerStart.sh and potentially settings.cfg and put them in `/data/FeedTheBeast`

An example of the latter would be to use https://github.com/AllTheMods/Server-Scripts
There, you'll find that all you have to do is put ServerStart.sh and settings.cfg into
`/data/FeedTheBeast`, taking care to update settings.cfg to specify your desired version
of minecraft and forge. You can do this in the cli with something like:

```
$ wget https://raw.githubusercontent.com/AllTheMods/Server-Scripts/master/ServerStart.sh
$ wget https://raw.githubusercontent.com/AllTheMods/Server-Scripts/master/settings.cfg
$ vim settings.cfg #update the forge version to the one you want. Your manifest.json will have it
$ chmod +x ServerStart.sh
$ docker run -itd --name derpcraft \
  -e MANIFEST=/data/FeedTheBeast/manifest.json \
  -v $PWD/ServerStart.sh:/data/FeedTheBeast/ServerStart.sh \
  -v $PWD/settings.cfg:/data/FeedTheBeast/settings.cfg \
  -e VERSION=1.12.2\
  -e TYPE=CURSEFORGE\
  -e CF_SERVER_MOD=https://minecraft.curseforge.com/projects/your_amazing_modpack/files/2670435/download\
  -p 25565:25565\
  -e EULA=TRUE\
  --restart=always\
  itzg/minecraft-server
```

Note the `CF_SERVER_MOD` env var should match the url to download the modpack you are targeting.
