### PR TITLE
Fix for custom curseforge modpacks that do not have mods dir

### DIFF
--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -75,9 +75,9 @@ if [[ "$MANIFEST" ]]; then
 case "X$MANIFEST" in
   X*.json)
     if [ -f "${MANIFEST}" ]; then
-      MOD_DIR=${FTB_BASE_DIR:-/data/mods}
+      MOD_DIR=${FTB_BASE_DIR:-/data}/mods
       echo "Starting manifest download..."
-      cat "${MANIFEST}" | jq -r '$.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
+      cat "${MANIFEST}" | jq -r '.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
       do
         if [ ! -f $MOD_DIR/${p}_${f}.jar ]
         then

--- a/minecraft-server/start-finalSetup02Modpack
+++ b/minecraft-server/start-finalSetup02Modpack
@@ -76,6 +76,11 @@ case "X$MANIFEST" in
   X*.json)
     if [ -f "${MANIFEST}" ]; then
       MOD_DIR=${FTB_BASE_DIR:-/data}/mods
+      if [ ! -d "$MOD_DIR" ]
+      then
+        echo "Creating mods dir $MOD_DIR"
+        mkdir -p "$MOD_DIR"
+      fi
       echo "Starting manifest download..."
       cat "${MANIFEST}" | jq -r '.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
       do


### PR DESCRIPTION
This is sort of a combo fix.

For one, it appears some modpacks have been generated without a 'mods' dir, so running the manifest download will fail without a 'mkdir'. This appears to just be a thing that happens with the newest modpacks.

There's also an issue with the jq expression where slurping and stdin syntax differ (the dollar sign shouldn't be used).