### PR TITLE
Updated PAPERMC CI URL and job name for older versions

### DIFF
--- a/minecraft-server/start-deployPaper
+++ b/minecraft-server/start-deployPaper
@@ -2,7 +2,7 @@
 
 export SERVER=paper_server.jar
 if [ ! -f $SERVER ]; then
-  job=PaperSpigot
+  job=Paper
   case "${VANILLA_VERSION}" in
     1.13.*)
       job=Paper-1.13
@@ -28,7 +28,7 @@ if [ ! -f $SERVER ]; then
 
   if [ $build != "nosupp" ]; then
     rm -f $SERVER
-    downloadUrl=${PAPER_DOWNLOAD_URL:-https://ci.destroystokyo.com/job/$job/$build/artifact/paperclip.jar}
+    downloadUrl=${PAPER_DOWNLOAD_URL:-https://papermc.io/ci/job/$job/$build/artifact/paperclip.jar}
     echo "Downloading Paper $VANILLA_VERSION from $downloadUrl ..."
     curl -fsSL -o $SERVER "$downloadUrl"
     if [ ! -f $SERVER ]; then
@@ -37,7 +37,7 @@ if [ ! -f $SERVER ]; then
     fi
   else
     echo "ERROR: Version $VERSION is not supported for $TYPE"
-    echo "       Refer to https://ci.destroystokyo.com/job/PaperSpigot/"
+    echo "       Refer to https://papermc.io/ci/"
     echo "       for supported versions"
     exit 2
   fi


### PR DESCRIPTION
There were some small changes done to PaperMc's CI urls for older versions of minecraft.