### PR TITLE
Allow user to specify that server properties be overridden on start

### DIFF
--- a/minecraft-server/start-finalSetup04ServerProperties
+++ b/minecraft-server/start-finalSetup04ServerProperties
@@ -17,17 +17,7 @@ function setServerProp {
   fi
 }
 
-# Deploy server.properties file
-if [ ! -e $SERVER_PROPERTIES ]; then
-  echo "Creating server.properties in ${SERVER_PROPERTIES}"
-  cp /tmp/server.properties $SERVER_PROPERTIES
-
-  if [[ ${TYPE} == "FEED-THE-BEAST" ]]; then
-    export SERVER_PROPERTIES=${FTB_DIR}/server.properties
-    echo "detected FTB, changing properties path to ${SERVER_PROPERTIES}"
-    cp /tmp/server.properties $SERVER_PROPERTIES
-  fi
-
+function customizeServerProps {
   if [ -n "$WHITELIST" ]; then
     echo "Creating whitelist"
     setServerProp "whitelist" "true"
@@ -128,6 +118,27 @@ if [ ! -e $SERVER_PROPERTIES ]; then
     esac
     setServerProp "gamemode" "$MODE"
   fi
+}
+
+# Deploy server.properties file
+if [[ ${TYPE} == "FEED-THE-BEAST" ]]; then
+  export SERVER_PROPERTIES=${FTB_DIR}/server.properties
+  echo "detected FTB, changing properties path to ${SERVER_PROPERTIES}"
+fi
+
+if [ ! -e $SERVER_PROPERTIES ]; then
+  echo "Creating server.properties in ${SERVER_PROPERTIES}"
+  cp /tmp/server.properties $SERVER_PROPERTIES
+  customizeServerProps
+elif [ -n "${OVERRIDE_SERVER_PROPERTIES}" ]; then
+    case ${OVERRIDE_SERVER_PROPERTIES^^} in
+      TRUE|1)
+        customizeServerProps
+        ;;
+      *)
+        echo "server.properties already created, skipping"
+        ;;
+    esac
 else
   echo "server.properties already created, skipping"
 fi


### PR DESCRIPTION
As discussed in #204 

This was motivated by the game-server-operator minecraft deployment logic, where we map a custom Kubernetes resource to a Minecraft instance. Ideally users would be able to change the Minecraft resource and have the deployed server configuration change to reflect this.

This only handles `server.properties` related environment variables, and doesn't resolve the mods-related variables (because I don't understand how minecraft modding works well enough to do that with confidence). It also doesn't handle ops/whitelist variables, I wasn't sure if I should make a broader `OVERRIDE_CONFIGURATION` and get rid of `OVERRIDE_SERVER_PROPERTIES`, or if it would be better to have more granular `OVERRIDE_OPS` + `OVERRIDE_WHITELIST` (maybe in addition to a general `OVERRIDE_CONFIGURATION`?). I lean towards one `OVERRIDE_CONFIGURATION` variable, but was curious what everyone else thought. 