### PR TITLE
add option for force re-download of server file

### DIFF
--- a/minecraft-server/README.md
+++ b/minecraft-server/README.md
@@ -537,6 +537,20 @@ If it is a URL, it will only be downloaded into the `/data` directory if it wasn
 such, if you need to upgrade or re-download the JAR, then you will need to stop the container,
 remove the file from the container's `/data` directory, and start again. 
 
+## Force re-download of the server file
+
+For VANILLA, FORGE, BUKKIT, SPIGOT, PAPER, CURSEFORGE, SPONGEVANILLA server types, set 
+`$FORCE_REDOWNLOAD` to some value (e.g. 'true) to force a re-download of the server file for 
+the particular server type. by adding a `-e FORCE_REDOWNLOAD=true` to your command-line.
+
+For example, with PaperSpigot, it would look something like this:
+
+```
+docker run -d -v /path/on/host:/data \
+    -e TYPE=PAPER -e VERSION=1.14.1 -e FORCE_REDOWNLOAD=true \
+    -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server
+```
+
 ## Using Docker Compose
 
 Rather than type the server options below, the port mappings above, etc

--- a/minecraft-server/start-deployBukkitSpigot
+++ b/minecraft-server/start-deployBukkitSpigot
@@ -72,7 +72,7 @@ case "$TYPE" in
     ;;
 esac
 
-if [ ! -f $SERVER ]; then
+if [ ! -f $SERVER ] || [ -n "$FORCE_REDOWNLOAD" ]; then
    if [[ "$BUILD_SPIGOT_FROM_SOURCE" = TRUE || "$BUILD_SPIGOT_FROM_SOURCE" = true || "$BUILD_FROM_SOURCE" = TRUE || "$BUILD_FROM_SOURCE" = true ]]; then
      buildSpigotFromSource
    else

--- a/minecraft-server/start-deployCustom
+++ b/minecraft-server/start-deployCustom
@@ -6,7 +6,7 @@ if isURL ${CUSTOM_SERVER}; then
   filename=$(basename ${CUSTOM_SERVER})
   export SERVER=/data/${filename}
 
-  if [[ -f ${SERVER} ]]; then
+  if [[ -f ${SERVER} ]] || [ -n "$FORCE_REDOWNLOAD" ]; then
     echo "Using previously downloaded jar at ${SERVER}"
   else
    echo "Downloading custom server jar from ${CUSTOM_SERVER} ..."

--- a/minecraft-server/start-deployPaper
+++ b/minecraft-server/start-deployPaper
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export SERVER=paper_server.jar
-if [ ! -f $SERVER ]; then
+if [ ! -f $SERVER ] || [ -n "$FORCE_REDOWNLOAD" ]; then
     downloadUrl=${PAPER_DOWNLOAD_URL:-https://papermc.io/api/v1/paper/${VANILLA_VERSION}/latest/download}
     echo "Downloading Paper $VANILLA_VERSION from $downloadUrl ..."
     curl -fsSL -o $SERVER "$downloadUrl"

--- a/minecraft-server/start-deploySpongeVanilla
+++ b/minecraft-server/start-deploySpongeVanilla
@@ -28,7 +28,7 @@ fi
 
 export SERVER="spongevanilla-$SPONGEVERSION.jar"
 
-if [ ! -e $SERVER ]; then
+if [ ! -e $SERVER ] || [ -n "$FORCE_REDOWNLOAD" ]; then
   echo "Downloading $SERVER ..."
   curl -sSL -o $SERVER https://repo.spongepowered.org/maven/org/spongepowered/$TYPE/$SPONGEVERSION/$SERVER
 fi

--- a/minecraft-server/start-deployVanilla
+++ b/minecraft-server/start-deployVanilla
@@ -5,7 +5,7 @@ set -o pipefail
 
 export SERVER="minecraft_server.${VANILLA_VERSION// /_}.jar"
 
-if [ ! -e $SERVER ]; then
+if [ ! -e $SERVER ] || [ -n "$FORCE_REDOWNLOAD" ]; then
   echo "Downloading $SERVER ..."
   debug "Finding version manifest for $VANILLA_VERSION"
   versionManifestUrl=$(curl -fsSL 'https://launchermeta.mojang.com/mc/game/version_manifest.json' | jq --arg VANILLA_VERSION "$VANILLA_VERSION" --raw-output '[.versions[]|select(.id == $VANILLA_VERSION)][0].url')


### PR DESCRIPTION
This may partially (or fully?) resolve #198 

In some scenarios, it is not ideal to manually delete the server .jar file in order to force minecraft-server to download a fresh copy.  For situations when a new version of minecraft is released and there is steady incremental fixes made to the server type, there are new versions of the server created multiple times a day (e.g. [the 81 builds of the paper server since 1.14 was releases](https://papermc.io/downloads#Paper-1.14)).  

The option added in this PR gives server operators the option to have minecraft-server automatically download a fresh, (most likely) updated copy of the server for that particular release of minecraft.