### PR TITLE
Change to 8u212

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u201-jre-alpine
+FROM openjdk:8u212-jre-slim
 
 LABEL maintainer "itzg"
 

--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-slim
+FROM openjdk:8u212-jre-alpine
 
 LABEL maintainer "itzg"
 


### PR DESCRIPTION
To have the java 8 properly take account for available memory usage available to the container.

https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54